### PR TITLE
Add anchors.txt to the translation

### DIFF
--- a/drpai/README.md
+++ b/drpai/README.md
@@ -3,9 +3,6 @@
 The python script is a translation layer to make the EdgeImpulse deployment usable for the 
 [Gstreamer DRPAI Plugin](https://github.com/MistySOM/gstreamer1.0-drpai). 
 
-> [!NOTE]
-> There is no dependency and virtual environment required for the script to run.
-
 To run the script, follow the instructions below:
 
 1. Extract the deployment file in a way that the working directory would like below:

--- a/drpai/README.md
+++ b/drpai/README.md
@@ -22,7 +22,15 @@ To run the script, follow the instructions below:
     
    As an example, the `yolov5-ei-sample.tar.gz` is provided for extracting. 
 
-2. Run the script with one parameter which is the name of the folder and prefix of files to create:
+2. Prepare a Python virtual environment and install the required dependencies in `requirements.txt`:
+
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   pip3 install -r requirements.txt
+   ```
+
+3. Run the script with one parameter which is the name of the folder and prefix of files to create:
    
    ```bash
    python3 ei2gst-drpai.py yolov5
@@ -44,30 +52,16 @@ To run the script, follow the instructions below:
       │   ├── drp_desc.bin
       │   ├── drp_param.bin
       │   ├── yolov5_addrmap_intm.txt
+      │   ├── yolov5_anchors.txt
       │   ├── yolov5_data_in_list.txt
       │   ├── yolov5_data_out_list.txt
       │   ├── yolov5_drpcfg.mem
       │   ├── yolov5_labels.txt
       │   ├── yolov5.part2
+      │   ├── yolov5_post_process_params.txt
       │   └── yolov5_weight.dat
-      └── ei2gst-drpai.py 
-      ```
-   </details>
-   
-3. As each model needs a different way of interpretation, 
-   create a file in the model's directory with the name `<model>/<model>_post_process_params.txt`
-   to adjust the post-processing parameters.
-
-   <details>
-      <summary>Example</summary>
-      YOLOv5 post-processing parameters are in the file `yolov5/yolov5_post_process_params.txt` and contains the following lines:
-
-      ```bash
-      [dynamic_library]
-      libgstdrpai-yolo.so
-      
-      [yolo_version]
-      5
+      ├── ei2gst-drpai.py   
+      └── requirements.txt
       ```
    </details>
    

--- a/drpai/requirements.txt
+++ b/drpai/requirements.txt
@@ -1,2 +1,2 @@
-numpy<2.0.0
+numpy<2
 tflite-runtime

--- a/drpai/requirements.txt
+++ b/drpai/requirements.txt
@@ -1,0 +1,2 @@
+numpy<2.0.0
+tflite-runtime


### PR DESCRIPTION
In this pull request, I use the `tflite-runtime` package (<2MB) to extract the anchor information from the `yolov5.part2` file.

Previously, I found the correct anchor by try and error but now I have a way to extract it.