### PR TITLE
Rename file to allow importing

### DIFF
--- a/drpai/README.md
+++ b/drpai/README.md
@@ -30,7 +30,7 @@ To run the script, follow the instructions below:
 3. Run the script with one parameter which is the name of the folder and prefix of files to create:
    
    ```bash
-   python3 ei2gst-drpai.py yolov5
+   python3 ei2gst_drpai.py yolov5
    ```
 
    <details>

--- a/drpai/ei2gst_drpai.py
+++ b/drpai/ei2gst_drpai.py
@@ -502,7 +502,7 @@ if __name__ == '__main__':
         model_name (str): The folder and prefix of files to create.
     
     Example:
-        $ python3 ei2gst-drpai.py model
+        $ python3 ei2gst_drpai.py model
     """
 
     parser = argparse.ArgumentParser(prog='EdgeImpulse2GstDRPAI',


### PR DESCRIPTION
The file name `ei2gst-drpai.py` is not suitable for importing.

Renaming it to `ei2gst_drpai.py` allows us to use the import below (specifically for YVR05):

```python
from ei2gst_drpai import EdgeImpulse2GstDRPAI
```